### PR TITLE
Rework parser

### DIFF
--- a/parser/parselets.go
+++ b/parser/parselets.go
@@ -71,14 +71,6 @@ func (CatParselet) Parse(p *Parser, left ast.Regex, t Token) (ast.Regex, error) 
 	}, nil
 }
 
-// ------------------------
-//     POSTFIX PARSELETS
-// ------------------------
-
-type PostfixParselet interface {
-	Parse(*Parser, ast.Regex, Token) (ast.Regex, error)
-}
-
 type StarParselet struct{}
 
 func (StarParselet) Parse(p *Parser, left ast.Regex, t Token) (ast.Regex, error) {

--- a/test/regex_test.go
+++ b/test/regex_test.go
@@ -86,6 +86,14 @@ func TestRegex(t *testing.T) {
 			regexS:     ".|aa",
 			mustAccept: []string{"a", "b", "c", "aa"},
 		},
+		{
+			regexS:     `a*|b*`,
+			mustAccept: []string{"", "a", "b", "aa", "bb"},
+		},
+		{
+			regexS:     `a|a*|b+`,
+			mustAccept: []string{"", "a", "aa", "aaa", "b"},
+		},
 	}
 	p := parser.NewParser()
 	for _, tc := range tt {


### PR DESCRIPTION
Rework parser - no need to have postfix parsers as a separate type since they are a subset of infix parsers.